### PR TITLE
Fix fallback for unsupported encodings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/on2itsecurity/parsemail
 
-go 1.12
+go 1.21
 
 require (
-	golang.org/x/net v0.0.0-20200927032502-5d4f70055728
-	golang.org/x/text v0.3.0
+	golang.org/x/net v0.15.0
+	golang.org/x/text v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,12 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
+golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/parsemail_on2it_test.go
+++ b/parsemail_on2it_test.go
@@ -63,6 +63,20 @@ func Test_decodeMimeSentence(t *testing.T) {
 			},
 			`John Do€`,
 		},
+		{
+			"utf-7",
+			args{
+				`=?utf-7?B?Sm9obiBEbytJS3ct?=`,
+			},
+			`(removed text: non supported encoder)`,
+		},
+		{
+			"gb2312",
+			args{
+				`=?gb2312?B?Sm9obiBEb2U=?=`,
+			},
+			`(removed text: non supported encoder)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,6 +152,26 @@ func Test_headerParser_parseAddress(t *testing.T) {
 			},
 			&mail.Address{
 				Name:    `John Do€`,
+				Address: `john.doe@example.com`,
+			},
+		},
+		{
+			"utf-7",
+			args{
+				`=?utf-7?B?Sm9obiBEbytJS3ct?= <john.doe@example.com>`,
+			},
+			&mail.Address{
+				Name:    `(removed text: non supported encoder)`,
+				Address: `john.doe@example.com`,
+			},
+		},
+		{
+			"gb2312",
+			args{
+				`=?gb2312?B?Sm9obiBEb2U=?= <john.doe@example.com>`,
+			},
+			&mail.Address{
+				Name:    `(removed text: non supported encoder)`,
 				Address: `john.doe@example.com`,
 			},
 		},
@@ -228,6 +262,49 @@ func Test_headerParser_parseAddressList(t *testing.T) {
 			[]*mail.Address{
 				{
 					Name:    `John Do€`,
+					Address: `john.doe@example.com`,
+				},
+			},
+		},
+		{
+			"utf-7",
+			args{
+				`=?utf-7?B?Sm9obiBEbytJS3ct?= <john.doe@example.com>`,
+			},
+			[]*mail.Address{
+				{
+					Name:    `(removed text: non supported encoder)`,
+					Address: `john.doe@example.com`,
+				},
+			},
+		},
+		{
+			"gb2312",
+			args{
+				`=?gb2312?B?Sm9obiBEb2U=?= <john.doe@example.com>`,
+			},
+			[]*mail.Address{
+				{
+					Name:    `(removed text: non supported encoder)`,
+					Address: `john.doe@example.com`,
+				},
+			},
+		},
+		{
+			"multiple_charsets with unsupported encoders",
+			args{
+				`test@example.com,=?utf-8?Q?John_D=C3=B8e?= <john.doe@example.com>,=?gb2312?B?Sm9obiBEb2U=?= <john.doe@example.com>`,
+			},
+			[]*mail.Address{
+				{
+					Address: `test@example.com`,
+				},
+				{
+					Name:    `John Døe`,
+					Address: `john.doe@example.com`,
+				},
+				{
+					Name:    `(removed text: non supported encoder)`,
 					Address: `john.doe@example.com`,
 				},
 			},


### PR DESCRIPTION
golang does not support all encodings like gb2312

see : https://github.com/golang/go/issues/24636 for example

to prevent a panic we need to have a fallback

see : https://pkg.go.dev/golang.org/x/text/encoding/ianaindex
see : https://cs.opensource.google/go/x/text/+/refs/tags/v0.13.0:encoding/ianaindex/tables.go
